### PR TITLE
Ensure mobile keyboards have decimal

### DIFF
--- a/lib/calculator/widgets/item_card.dart
+++ b/lib/calculator/widgets/item_card.dart
@@ -313,7 +313,7 @@ class _NumericInputWidget extends StatelessWidget {
             controller: _controller,
             textAlign: TextAlign.center,
             inputFormatters: [BetterTextInputFormatter.doubleOnly],
-            keyboardType: const TextInputType.numberWithOptions(),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
             textInputAction: TextInputAction.next,
             onSubmitted: (_) {
               _updateItem(item);


### PR DESCRIPTION
Android did, but iOS wasn't bothering